### PR TITLE
Fix ALG_RSA_NOPAD cryptographic operation for input blocks that are same size as RSA key

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
@@ -21,6 +21,7 @@ import javacard.security.CryptoException;
 import javacard.security.Key;
 import javacardx.crypto.Cipher;
 import org.bouncycastle.crypto.AsymmetricBlockCipher;
+import org.bouncycastle.crypto.DataLengthException;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.encodings.OAEPEncoding;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
@@ -99,7 +100,7 @@ public class AsymmetricCipherImpl extends Cipher {
             if ((outBuff.length - outOffset) < engine.getOutputBlockSize()) {
                 CryptoException.throwIt(CryptoException.ILLEGAL_USE);
             }
-            if ((inLength - inOffset) > engine.getInputBlockSize()) {
+            if ((inLength - inOffset) > engine.getInputBlockSize() + (algorithm == ALG_RSA_NOPAD ? 1 : 0)) {
                 CryptoException.throwIt(CryptoException.ILLEGAL_USE);
             }
         }
@@ -116,7 +117,7 @@ public class AsymmetricCipherImpl extends Cipher {
             Util.arrayCopyNonAtomic(data, (short) 0, outBuff, outOffset, (short) data.length);
             bufferPos = 0;
             return (short) data.length;
-        } catch (InvalidCipherTextException ex) {
+        } catch (InvalidCipherTextException | DataLengthException ex) {
             CryptoException.throwIt(CryptoException.ILLEGAL_USE);
         }
         return -1;

--- a/src/test/java/com/licel/jcardsim/crypto/AsymmetricCipherImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/AsymmetricCipherImplTest.java
@@ -47,17 +47,37 @@ public class AsymmetricCipherImplTest extends TestCase {
      * SelfTest of RSA Encryption/Decryption, of class AsymmetricCipherImpl.
      */
     public void testSelftRSA_NOPAD(){
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, (short) ((KeyBuilder.LENGTH_RSA_512/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_736, (short) ((KeyBuilder.LENGTH_RSA_736/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_768, (short) ((KeyBuilder.LENGTH_RSA_768/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_896, (short) ((KeyBuilder.LENGTH_RSA_896/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1024, (short) ((KeyBuilder.LENGTH_RSA_1024/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1280, (short) ((KeyBuilder.LENGTH_RSA_1280/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1536, (short) ((KeyBuilder.LENGTH_RSA_1536/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1984, (short) ((KeyBuilder.LENGTH_RSA_1984/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_2048, (short) ((KeyBuilder.LENGTH_RSA_2048/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_3072, (short) ((KeyBuilder.LENGTH_RSA_3072/Byte.SIZE) - 1));
-        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_4096, (short) ((KeyBuilder.LENGTH_RSA_4096/Byte.SIZE) - 1));
+        // Refer to https://docs.oracle.com/javacard/3.0.5/api/javacardx/crypto/Cipher.html#ALG_RSA_NOPAD
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, (short) ((KeyBuilder.LENGTH_RSA_512/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_736, (short) ((KeyBuilder.LENGTH_RSA_736/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_768, (short) ((KeyBuilder.LENGTH_RSA_768/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_896, (short) ((KeyBuilder.LENGTH_RSA_896/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1024, (short) ((KeyBuilder.LENGTH_RSA_1024/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1280, (short) ((KeyBuilder.LENGTH_RSA_1280/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1536, (short) ((KeyBuilder.LENGTH_RSA_1536/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1984, (short) ((KeyBuilder.LENGTH_RSA_1984/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_2048, (short) ((KeyBuilder.LENGTH_RSA_2048/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_3072, (short) ((KeyBuilder.LENGTH_RSA_3072/Byte.SIZE)));
+        testSelftRSA_NOPAD(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_4096, (short) ((KeyBuilder.LENGTH_RSA_4096/Byte.SIZE)));
+
+        try{
+            short messageLen = (short) ((KeyBuilder.LENGTH_RSA_512/Byte.SIZE));
+            byte[] msgEqualOrGreaterThanRsaModulus = new byte[messageLen];
+            Arrays.fill(msgEqualOrGreaterThanRsaModulus, (byte) 0xFF);
+            testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, messageLen, msgEqualOrGreaterThanRsaModulus);
+            assert(false);
+        }
+        catch (CryptoException ex) {
+            assertEquals(CryptoException.ILLEGAL_USE, ex.getReason());
+        }
+    }
+
+    private void testSelftRSA_NOPAD(byte algorithm, byte keyPairAlgorithm, short keySizeInBits, short messageLen){
+        byte[] msg = new byte[messageLen];
+        new Random().nextBytes(msg);
+        msg[0] = (byte) 0x01; // Ensure that message is not greater than RSA modulus
+
+        testSelftRSA(algorithm, keyPairAlgorithm, keySizeInBits, messageLen, msg);
     }
     
     public void testSelftRSA_PKCS1(){
@@ -280,6 +300,12 @@ public class AsymmetricCipherImplTest extends TestCase {
     }
 
     private void testSelftRSA(byte algorithm, byte keyPairAlgorithm, short keySizeInBits, short messageLen) {
+        byte[] msg = new byte[messageLen];
+        new Random().nextBytes(msg);
+        testSelftRSA(algorithm, keyPairAlgorithm, keySizeInBits, messageLen, msg);
+    }
+
+    private void testSelftRSA(byte algorithm, byte keyPairAlgorithm, short keySizeInBits, short messageLen, byte[] msg) {
         Cipher cipher = Cipher.getInstance(algorithm, false);
         KeyPair kp = new KeyPair(keyPairAlgorithm, keySizeInBits);
         kp.genKeyPair();
@@ -287,14 +313,12 @@ public class AsymmetricCipherImplTest extends TestCase {
         cipher.init(kp.getPublic(), Cipher.MODE_ENCRYPT);
 
         short keySizeInBytes = (short) (keySizeInBits/Byte.SIZE);
-        byte[] msg = new byte[messageLen];
         byte[] encryptedMsg = new byte[keySizeInBytes];
-        new Random().nextBytes(msg);
 
-        cipher.doFinal(msg, (short) 0, (short) msg.length, encryptedMsg, (short) 0);
+        cipher.doFinal(msg, (short) 0, messageLen, encryptedMsg, (short) 0);
 
         cipher.init(kp.getPrivate(), Cipher.MODE_DECRYPT);
-        byte[] decryptedMsg = new byte[msg.length];
+        byte[] decryptedMsg = new byte[messageLen];
         cipher.doFinal(encryptedMsg, (short) 0, (short) encryptedMsg.length, decryptedMsg, (short) 0);
 
         assertEquals(true, Arrays.areEqual(msg, decryptedMsg));


### PR DESCRIPTION
Fixing the issue that ALG_RSA_NOPAD cipher cryptographic operation cannot be used if input block for encryption operation is same size as the RSA key length.

- Issue is due to new validation rule being stricter than JavaCard specifications: https://github.com/ph4r05/jcardsim/blob/6c6fa184c095c32de3b4672470c441c9f762bc75/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java#L103 
- This bug has appeared after jcardsim version 3.0.5.11
- https://docs.oracle.com/javacard/3.0.5/api/javacardx/crypto/Cipher.html#ALG_RSA_NOPAD specifies that input block data can have same amount of bytes as the RSA key as long as the input block is not equal or greater to RSA modulus.
- BouncyCastle has stricter approach than JavaCard what comes to getInputBlockSize method https://github.com/bcgit/bc-java/blob/c62e5d0aaa222dfbba2422d8249f9e28a1c64158/core/src/main/java/org/bouncycastle/crypto/engines/RSACoreEngine.java#L57 but it is capable of handling RSA input blocks that are same size as the key as long as the input block is less than RSA modulus.